### PR TITLE
Add custom `PropMarshaler` and `PropUnmarshaler` interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # dotprops
 
 ![ci](https://github.com/rhajizada/dotprops/actions/workflows/ci.yml/badge.svg)
+![Go](https://img.shields.io/badge/Go-1.22-blue.svg)
+![License](https://img.shields.io/badge/License-MIT-green.svg)
+
 
 dotprops is a `Go` package for marshalling and unmarshalling `Java` `.properties`
 files into structs, similar to how the `encoding/json` package works.
@@ -11,6 +14,10 @@ files into structs, similar to how the `encoding/json` package works.
 - **Unmarshal `.properties` files** into Go structs.
 - Supports **nested structures**.
 - Handles **optional fields** via pointers.
+- Custom property marshaling and unmarshaling via `PropMarshaler` and `
+PropUnmarshaler` interfaces.
+- Custom text marshaling and unmarshaling via `TextMarshaler` and
+  `TextUnmarshaler` interfaces.
 
 ## Installation
 
@@ -144,7 +151,8 @@ app.port=8080
 
 ### Nested structures
 
-`dotprops` supports nested structs to represent hierarchical properties using dot notation.
+`dotprops` supports nested structs to represent hierarchical properties using
+dot notation.
 
 ```go
 package main
@@ -246,3 +254,422 @@ database.password=secret
     }
 }
 ```
+
+### Custom Marshaling and Unmarshaling Interfaces
+
+`dotprops` provides two sets of interfaces to allow for custom serialization and
+deserialization behaviors:
+
+- `TextMarshaler` and `TextUnmarshaler`
+- `PropMarshaler` and `PropUnmarshaler`
+
+#### TextMarshaler and TextUnmarshaler
+
+These interfaces are similar to those provided by Go's encoding packages and
+allow you to define custom text-based serialization for individual fields.
+
+**Marshalling Example:**
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/rhajizada/dotprops"
+)
+
+// CustomString implements TextMarshaler and TextUnmarshaler
+type CustomString string
+
+func (cs CustomString) MarshalText() ([]byte, error) {
+    return []byte(fmt.Sprintf("custom_%s", cs)), nil
+}
+
+func (cs *CustomString) UnmarshalText(text []byte) error {
+    if len(text) < 8 || string(text[:7]) != "custom_" {
+        return fmt.Errorf("invalid prefix in value: %s", text)
+    }
+    *cs = CustomString(string(text[7:]))
+    return nil
+}
+
+type Config struct {
+    Name CustomString `property:"name"`
+}
+
+func main() {
+    config := Config{
+        Name: "example",
+    }
+
+    data, err := dotprops.Marshal(&config)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println(string(data))
+}
+```
+
+**Unmarshalling Example:**
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/rhajizada/dotprops"
+)
+
+// CustomString implements TextMarshaler and TextUnmarshaler
+type CustomString string
+
+func (cs CustomString) MarshalText() ([]byte, error) {
+    return []byte(fmt.Sprintf("custom_%s", cs)), nil
+}
+
+func (cs *CustomString) UnmarshalText(text []byte) error {
+    if len(text) < 8 || string(text[:7]) != "custom_" {
+        return fmt.Errorf("invalid prefix in value: %s", text)
+    }
+    *cs = CustomString(string(text[7:]))
+    return nil
+}
+
+type Config struct {
+    Name CustomString `property:"name"`
+}
+
+func main() {
+    data := []byte(`
+name=custom_example
+`)
+
+    var config Config
+    err := dotprops.Unmarshal(data, &config)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("Name: %s\n", config.Name)
+}
+```
+
+#### PropMarshaler and PropUnmarshaler
+
+These custom interfaces allow for more granular control over how individual
+properties are marshaled and unmarshaled, especially useful for complex or
+specialized data formats.
+
+**Defining Custom Interfaces:**
+
+First, define the `PropMarshaler` and `PropUnmarshaler` interfaces within your package:
+
+```go
+package dotprops
+
+// PropMarshaler allows custom marshaling of a single property.
+type PropMarshaler interface {
+    MarshalProp() (key string, value string, err error)
+}
+
+// PropUnmarshaler allows custom unmarshaling of a single property.
+type PropUnmarshaler interface {
+    UnmarshalProp(key string, value string) error
+}
+```
+
+**Marshalling with PropMarshaler:**
+
+Implement the PropMarshaler interface in your custom type to control how a
+specific field is marshaled.
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/rhajizada/dotprops"
+)
+
+// CustomPropMarshaller implements PropMarshaler
+type CustomPropMarshaller struct {
+    Field1 string
+    Field2 int
+}
+
+func (c CustomPropMarshaller) MarshalProp() (string, string, error) {
+    key := "custom.field"
+    value := fmt.Sprintf("%s_%d", c.Field1, c.Field2)
+    return key, value, nil
+}
+
+type Config struct {
+    CustomField CustomPropMarshaller `property:"custom.field"`
+    Name        string               `property:"name"`
+}
+
+func main() {
+    config := Config{
+        CustomField: CustomPropMarshaller{
+            Field1: "value1",
+            Field2: 42,
+        },
+        Name: "TestService",
+    }
+
+    data, err := dotprops.Marshal(&config)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println(string(data))
+}
+
+```
+
+**Handling Errors in PropMarshaler:**
+
+If your PropMarshaler implementation encounters an error during marshaling, it
+should return it to ensure that the Marshal function can handle it appropriately.
+
+```go
+package main
+
+import (
+    "errors"
+    "fmt"
+    "log"
+
+    "github.com/rhajizada/dotprops"
+)
+
+// FaultyPropMarshaller implements PropMarshaler and always returns an error
+type FaultyPropMarshaller struct{}
+
+func (f FaultyPropMarshaller) MarshalProp() (string, string, error) {
+    return "", "", errors.New("intentional marshaling error")
+}
+
+type Config struct {
+    FaultyField FaultyPropMarshaller `property:"faulty.field"`
+    Name        string               `property:"name"`
+}
+
+func main() {
+    config := Config{
+        FaultyField: FaultyPropMarshaller{},
+        Name:        "FaultyService",
+    }
+
+    _, err := dotprops.Marshal(&config)
+    if err != nil {
+        log.Fatalf("Marshal failed: %v", err)
+    }
+}
+```
+
+**Unmarshalling with PropUnmarshaler:**
+
+Implement the PropUnmarshaler interface in your custom type to control how
+a specific field is unmarshaled.
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "strconv"
+    "strings"
+
+    "github.com/rhajizada/dotprops"
+)
+
+// CustomPropUnmarshaller implements PropUnmarshaler
+type CustomPropUnmarshaller struct {
+    Field1 string
+    Field2 int
+}
+
+func (c *CustomPropUnmarshaller) UnmarshalProp(key string, value string) error {
+    if key != "custom.field" {
+        return fmt.Errorf("unexpected key: %s", key)
+    }
+    parts := strings.Split(value, "_")
+    if len(parts) != 2 {
+        return fmt.Errorf("invalid value format: %s", value)
+    }
+    c.Field1 = parts[0]
+    var err error
+    c.Field2, err = strconv.Atoi(parts[1])
+    if err != nil {
+        return err
+    }
+    return nil
+}
+
+type Config struct {
+    CustomField CustomPropUnmarshaller `property:"custom.field"`
+    Name        string                  `property:"name"`
+}
+
+func main() {
+    data := []byte(`
+custom.field=value1_42
+name=TestService
+`)
+
+    var config Config
+    err := dotprops.Unmarshal(data, &config)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("CustomField: %+v\n", config.CustomField)
+    fmt.Printf("Name: %s\n", config.Name)
+}
+```
+
+**Handling Errors in PropUnmarshaler:**
+
+If your PropUnmarshaler implementation encounters an error during unmarshaling,
+it should return it to ensure that the Unmarshal function can handle it
+appropriately.
+
+```go
+package main
+
+import (
+    "errors"
+    "fmt"
+    "log"
+
+    "github.com/rhajizada/dotprops"
+)
+
+// FaultyPropUnmarshaller implements PropUnmarshaler and always returns an error
+type FaultyPropUnmarshaller struct{}
+
+func (f *FaultyPropUnmarshaller) UnmarshalProp(key string, value string) error {
+    return errors.New("intentional unmarshaling error")
+}
+
+type Config struct {
+    FaultyField FaultyPropUnmarshaller `property:"faulty.field"`
+    Name        string                  `property:"name"`
+}
+
+func main() {
+    data := []byte(`
+faulty.field=invalid_value
+name=FaultyService
+`)
+
+    var config Config
+    err := dotprops.Unmarshal(data, &config)
+    if err != nil {
+        log.Fatalf("Unmarshal failed: %v", err)
+    }
+
+    fmt.Printf("FaultyField: %+v\n", config.FaultyField)
+    fmt.Printf("Name: %s\n", config.Name)
+}
+```
+
+**Combining TextMarshaler/Unmarshaler with PropMarshaler/Unmarshaler:**
+
+You can seamlessly integrate custom marshaling and unmarshaling interfaces
+within the same struct, allowing for flexible and granular control over how each
+field is processed.
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+    "strconv"
+    "strings"
+
+    "github.com/rhajizada/dotprops"
+)
+
+// CustomString implements TextMarshaler and TextUnmarshaler
+type CustomString string
+
+func (cs CustomString) MarshalText() ([]byte, error) {
+    return []byte(fmt.Sprintf("custom_%s", cs)), nil
+}
+
+func (cs *CustomString) UnmarshalText(text []byte) error {
+    if len(text) < 8 || string(text[:7]) != "custom_" {
+        return fmt.Errorf("invalid prefix in value: %s", text)
+    }
+    *cs = CustomString(string(text[7:]))
+    return nil
+}
+
+// CustomPropMarshaller implements PropMarshaler
+type CustomPropMarshaller struct {
+    Field1 string
+    Field2 int
+}
+
+func (c CustomPropMarshaller) MarshalProp() (string, string, error) {
+    key := "custom.field"
+    value := fmt.Sprintf("%s_%d", c.Field1, c.Field2)
+    return key, value, nil
+}
+
+// CustomPropUnmarshaller implements PropUnmarshaler
+type CustomPropUnmarshaller struct {
+    Field1 string
+    Field2 int
+}
+
+func (c *CustomPropUnmarshaller) UnmarshalProp(key string, value string) error {
+    if key != "custom.field" {
+        return fmt.Errorf("unexpected key: %s", key)
+    }
+    parts := strings.Split(value, "_")
+    if len(parts) != 2 {
+        return fmt.Errorf("invalid value format: %s", value)
+    }
+    c.Field1 = parts[0]
+    var err error
+    c.Field2, err = strconv.Atoi(parts[1])
+    if err != nil {
+        return err
+    }
+    return nil
+}
+
+type Config struct {
+    Name        CustomString           `property:"name"`
+    CustomField CustomPropUnmarshaller `property:"custom.field"`
+}
+
+func main() {
+    data := []byte(`
+name=custom_example
+custom.field=value1_42
+`)
+
+    var config Config
+    err := dotprops.Unmarshal(data, &config)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("Name: %s\n", config.Name)
+    fmt.Printf("CustomField: %+v\n", config.CustomField)
+}
+```
+

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,75 @@
+package dotprops
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+// Shared Test Structures
+
+type SimpleConfig struct {
+	AppName string `property:"app.name"`
+	Port    int    `property:"app.port"`
+	Debug   bool   `property:"app.debug"`
+}
+
+type NestedConfig struct {
+	AppName  string         `property:"app.name"`
+	Database DatabaseConfig `property:"database"`
+}
+
+type DatabaseConfig struct {
+	Host     string `property:"host"`
+	Port     int    `property:"port"`
+	Username string `property:"username"`
+	Password string `property:"password"`
+}
+
+type OptionalConfig struct {
+	AppName *string `property:"app.name"`
+	Port    *int    `property:"app.port"`
+	Debug   *bool   `property:"app.debug"`
+}
+
+type ConfigWithPointer struct {
+	AppName  string          `property:"app.name"`
+	Database *DatabaseConfig `property:"database"`
+}
+
+// Custom Types Implementing Interfaces for Testing
+
+// CustomString implements TextMarshaler and TextUnmarshaler
+type CustomString string
+
+func (cs CustomString) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("custom_%s", cs)), nil
+}
+
+func (cs *CustomString) UnmarshalText(text []byte) error {
+	if len(text) < 8 || string(text[:7]) != "custom_" {
+		return errors.New("invalid prefix")
+	}
+	*cs = CustomString(string(text[7:]))
+	return nil
+}
+
+// CustomInt implements TextMarshaler and TextUnmarshaler
+type CustomInt int
+
+func (ci CustomInt) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("custom_%d", ci)), nil
+}
+
+func (ci *CustomInt) UnmarshalText(text []byte) error {
+	if len(text) < 7 || string(text[:7]) != "custom_" {
+		return errors.New("invalid prefix")
+	}
+	numStr := string(text[7:])
+	num, err := strconv.Atoi(numStr)
+	if err != nil {
+		return err
+	}
+	*ci = CustomInt(num)
+	return nil
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -37,6 +37,21 @@ type ConfigWithPointer struct {
 	Database *DatabaseConfig `property:"database"`
 }
 
+type MultiLevelNestedConfig struct {
+	Service ServiceConfig `property:"service"`
+}
+
+type ServiceConfig struct {
+	Name     string         `property:"name"`
+	Endpoint EndpointConfig `property:"endpoint"`
+}
+
+type EndpointConfig struct {
+	URL    string `property:"url"`
+	Port   int    `property:"port"`
+	Active bool   `property:"active"`
+}
+
 // Custom Types Implementing Interfaces for Testing
 
 // CustomString implements TextMarshaler and TextUnmarshaler
@@ -71,5 +86,25 @@ func (ci *CustomInt) UnmarshalText(text []byte) error {
 		return err
 	}
 	*ci = CustomInt(num)
+	return nil
+}
+
+// CustomFloat implements TextMarshaler and TextUnmarshaler
+type CustomFloat float64
+
+func (cf CustomFloat) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("custom_%.2f", cf)), nil
+}
+
+func (cf *CustomFloat) UnmarshalText(text []byte) error {
+	if len(text) < 8 || string(text[:7]) != "custom_" {
+		return errors.New("invalid prefix")
+	}
+	numStr := string(text[7:])
+	num, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return err
+	}
+	*cf = CustomFloat(num)
 	return nil
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,0 +1,21 @@
+package dotprops
+
+// TextMarshaler interface as defined in the encoding package
+type TextMarshaler interface {
+	MarshalText() (text []byte, err error)
+}
+
+// TextUnmarshaler interface as defined in the encoding package
+type TextUnmarshaler interface {
+	UnmarshalText(text []byte) error
+}
+
+// PropMarshaler allows custom marshaling of a single property.
+type PropMarshaler interface {
+	MarshalProp() (key string, value string, err error)
+}
+
+// PropUnmarshaller allows custom unmarshaling of a single property.
+type PropUnmarshaller interface {
+	UnmarshalProp(key string, value string) error
+}

--- a/marshal.go
+++ b/marshal.go
@@ -14,8 +14,6 @@ type TextMarshaler interface {
 
 // Marshal returns the properties encoding of v.
 // v must be a struct.
-// Marshal returns the properties encoding of v.
-// v must be a struct or a pointer to a struct.
 func Marshal(v interface{}) ([]byte, error) {
 	val := reflect.ValueOf(v)
 	if val.Kind() == reflect.Ptr {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -471,3 +471,44 @@ func TestMarshalWithExtraProperties(t *testing.T) {
 		t.Errorf("Expected:\n%s\nGot:\n%s", expected, data)
 	}
 }
+
+// TestMarshalWithPropMarshaler tests marshalling with PropMarshaler interface
+func TestMarshalWithPropMarshaler(t *testing.T) {
+	type CustomConfig struct {
+		CustomField CustomPropMarshaller `property:"custom.field"`
+		Name        string               `property:"name"`
+	}
+
+	config := &CustomConfig{
+		CustomField: CustomPropMarshaller{
+			Field1: "value1",
+			Field2: 42,
+		},
+		Name: "TestService",
+	}
+
+	expected := "custom.field=value1_42\nname=TestService\n"
+
+	data, err := Marshal(config)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	if string(data) != expected {
+		t.Errorf("Expected:\n%s\nGot:\n%s", expected, data)
+	}
+}
+
+// TestMarshalWithPropMarshalerError tests marshalling when PropMarshaler returns an error
+func TestMarshalWithPropMarshalerError(t *testing.T) {
+
+	config := &FaultyConfig{
+		FaultyField: FaultyPropMarshaller{},
+		Name:        "FaultyService",
+	}
+
+	_, err := Marshal(config)
+	if err == nil {
+		t.Fatal("Expected Marshal to fail due to PropMarshaler error, but it did not")
+	}
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,6 +1,7 @@
 package dotprops
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -145,5 +146,127 @@ func TestMarshalWithTextMarshaler(t *testing.T) {
 
 	if string(data) != expected {
 		t.Errorf("Expected:\n%s\nGot:\n%s", expected, data)
+	}
+}
+
+type FaultyCustomString string
+
+// Implement TextMarshaler that returns an error
+func (fcs FaultyCustomString) MarshalText() ([]byte, error) {
+	return nil, errors.New("marshal error")
+}
+
+type ErrorConfig struct {
+	Name FaultyCustomString `property:"name"`
+}
+
+func TestMarshalWithTextMarshalerError(t *testing.T) {
+	config := &ErrorConfig{
+		Name: "faulty",
+	}
+	_, err := Marshal(config)
+	if err == nil {
+		t.Fatal("Expected Marshal to fail due to TextMarshaler error, but it did not")
+	}
+}
+
+// Additional Tests to Increase Coverage
+
+func TestMarshalWithUintAndFloatFields(t *testing.T) {
+	type NumericConfig struct {
+		MaxUsers  uint    `property:"max.users"`
+		Threshold float64 `property:"threshold"`
+	}
+
+	config := &NumericConfig{
+		MaxUsers:  1000,
+		Threshold: 75.5,
+	}
+
+	expected := "max.users=1000\nthreshold=75.500000\n"
+
+	data, err := Marshal(config)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	if string(data) != expected {
+		t.Errorf("Expected:\n%s\nGot:\n%s", expected, data)
+	}
+}
+
+func TestMarshalWithMultiLevelNestedStruct(t *testing.T) {
+	config := &MultiLevelNestedConfig{
+		Service: ServiceConfig{
+			Name: "AuthService",
+			Endpoint: EndpointConfig{
+				URL:    "https://auth.example.com",
+				Port:   443,
+				Active: true,
+			},
+		},
+	}
+
+	expected := "service.endpoint.active=true\nservice.endpoint.port=443\nservice.endpoint.url=https://auth.example.com\nservice.name=AuthService\n"
+
+	data, err := Marshal(config)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	if string(data) != expected {
+		t.Errorf("Expected:\n%s\nGot:\n%s", expected, data)
+	}
+}
+
+func TestMarshalWithEmbeddedStruct(t *testing.T) {
+	type BaseConfig struct {
+		Version string `property:"version"`
+	}
+
+	type EmbeddedConfig struct {
+		BaseConfig
+		Name string `property:"name"`
+	}
+
+	config := &EmbeddedConfig{
+		BaseConfig: BaseConfig{
+			Version: "1.0.0",
+		},
+		Name: "EmbeddedService",
+	}
+
+	expected := "name=EmbeddedService\nversion=1.0.0\n"
+
+	data, err := Marshal(config)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	if string(data) != expected {
+		t.Errorf("Expected:\n%s\nGot:\n%s", expected, data)
+	}
+}
+
+func TestMarshalWithUnsupportedNestedStruct(t *testing.T) {
+	type InnerUnsupported struct {
+		Data []string `property:"data"`
+	}
+
+	type OuterConfig struct {
+		Name  string           `property:"name"`
+		Inner InnerUnsupported `property:"inner"`
+	}
+
+	config := &OuterConfig{
+		Name: "Outer",
+		Inner: InnerUnsupported{
+			Data: []string{"one", "two"},
+		},
+	}
+
+	_, err := Marshal(config)
+	if err == nil {
+		t.Fatal("Expected Marshal to fail due to unsupported nested struct field type, but it did not")
 	}
 }

--- a/properties.go
+++ b/properties.go
@@ -95,6 +95,26 @@ func setStructFields(structVal reflect.Value, props map[string]interface{}) erro
 			continue
 		}
 
+		// Check if the field is embedded (anonymous)
+		if fieldType.Anonymous {
+			// Handle embedded struct: pass the same props map
+			if field.Kind() == reflect.Struct {
+				err := setStructFields(field, props)
+				if err != nil {
+					return err
+				}
+			} else if field.Kind() == reflect.Ptr && field.Type().Elem().Kind() == reflect.Struct {
+				if field.IsNil() {
+					field.Set(reflect.New(field.Type().Elem()))
+				}
+				err := setStructFields(field.Elem(), props)
+				if err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
 		// Get the property key from the struct tag or use the field name
 		propertyKey := fieldType.Tag.Get("property")
 		if propertyKey == "" {
@@ -109,47 +129,53 @@ func setStructFields(structVal reflect.Value, props map[string]interface{}) erro
 
 		// Handle nested structs
 		if field.Kind() == reflect.Struct {
-			if valueMap, ok := value.(map[string]interface{}); ok {
-				// Recursively set fields of the nested struct
-				if err := setStructFields(field, valueMap); err != nil {
-					return fmt.Errorf("error setting nested struct '%s': %v", fieldType.Name, err)
+			// The properties should be nested under propertyKey
+			if subProps, ok := value.(map[string]interface{}); ok {
+				err := setStructFields(field, subProps)
+				if err != nil {
+					return err
 				}
 			} else {
-				return fmt.Errorf("expected map for nested struct '%s', got %T", fieldType.Name, value)
+				return fmt.Errorf("expected map for nested struct field '%s', got %T", propertyKey, value)
 			}
-		} else if field.Kind() == reflect.Ptr && field.Type().Elem().Kind() == reflect.Struct {
+			continue
+		}
+
+		// Handle pointer to struct
+		if field.Kind() == reflect.Ptr && field.Type().Elem().Kind() == reflect.Struct {
 			if valueMap, ok := value.(map[string]interface{}); ok {
-				// Initialize the pointer to a new struct if nil
 				if field.IsNil() {
 					field.Set(reflect.New(field.Type().Elem()))
 				}
-				// Recursively set fields of the nested struct
-				if err := setStructFields(field.Elem(), valueMap); err != nil {
-					return fmt.Errorf("error setting nested struct '%s': %v", fieldType.Name, err)
+				err := setStructFields(field.Elem(), valueMap)
+				if err != nil {
+					return err
 				}
 			} else {
-				return fmt.Errorf("expected map for nested struct pointer '%s', got %T", fieldType.Name, value)
+				return fmt.Errorf("expected map for nested struct pointer field '%s', got %T", propertyKey, value)
+			}
+			continue
+		}
+
+		// Check if the field implements TextUnmarshaler
+		if field.CanInterface() {
+			if unmarshaler, ok := field.Addr().Interface().(TextUnmarshaler); ok {
+				err := unmarshaler.UnmarshalText([]byte(value.(string)))
+				if err != nil {
+					return fmt.Errorf("error unmarshaling field '%s': %v", propertyKey, err)
+				}
+				continue
+			}
+		}
+
+		// Set the field value
+		if valueStr, ok := value.(string); ok {
+			err := setFieldValue(field, valueStr)
+			if err != nil {
+				return fmt.Errorf("error setting field '%s': %v", propertyKey, err)
 			}
 		} else {
-			// Check if the field implements TextUnmarshaler
-			if field.CanInterface() {
-				if unmarshaler, ok := field.Addr().Interface().(TextUnmarshaler); ok {
-					err := unmarshaler.UnmarshalText([]byte(value.(string)))
-					if err != nil {
-						return fmt.Errorf("error unmarshaling field '%s': %v", propertyKey, err)
-					}
-					continue
-				}
-			}
-
-			// Set the field value
-			if valueStr, ok := value.(string); ok {
-				if err := setFieldValue(field, valueStr); err != nil {
-					return fmt.Errorf("error setting field '%s': %v", propertyKey, err)
-				}
-			} else {
-				return fmt.Errorf("expected string value for field '%s', got %T", propertyKey, value)
-			}
+			return fmt.Errorf("expected string value for field '%s', got %T", propertyKey, value)
 		}
 	}
 

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -5,12 +5,6 @@ import (
 	"reflect"
 )
 
-// TextUnmarshaler interface as defined in the encoding package
-type TextUnmarshaler interface {
-	UnmarshalText(text []byte) error
-}
-
-// Unmarshal parses the properties data and populates the provided struct.
 func Unmarshal(data []byte, v interface{}) error {
 	val := reflect.ValueOf(v)
 

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -5,6 +5,11 @@ import (
 	"reflect"
 )
 
+// TextUnmarshaler interface as defined in the encoding package
+type TextUnmarshaler interface {
+	UnmarshalText(text []byte) error
+}
+
 // Unmarshal parses the properties data and populates the provided struct.
 func Unmarshal(data []byte, v interface{}) error {
 	val := reflect.ValueOf(v)

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -710,3 +710,46 @@ func TestUnmarshalWithWhitespace(t *testing.T) {
 		t.Errorf("Expected Port 8080, got %d", config.Port)
 	}
 }
+
+// TestUnmarshalWithPropUnmarshaler tests unmarshalling with PropUnmarshaler interface
+func TestUnmarshalWithPropUnmarshaler(t *testing.T) {
+	type CustomConfig struct {
+		CustomField CustomPropUnmarshaller `property:"custom.field"`
+		Name        string                 `property:"name"`
+	}
+
+	data := []byte(`
+custom.field=value1_42
+name=TestService
+`)
+
+	var config CustomConfig
+	err := Unmarshal(data, &config)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if config.CustomField.Field1 != "value1" {
+		t.Errorf("Expected CustomField.Field1 'value1', got '%s'", config.CustomField.Field1)
+	}
+	if config.CustomField.Field2 != 42 {
+		t.Errorf("Expected CustomField.Field2 42, got %d", config.CustomField.Field2)
+	}
+	if config.Name != "TestService" {
+		t.Errorf("Expected Name 'TestService', got '%s'", config.Name)
+	}
+}
+
+// TestUnmarshalWithPropUnmarshalerError tests unmarshalling when PropUnmarshaler returns an error
+func TestUnmarshalWithPropUnmarshalerError(t *testing.T) {
+	data := []byte(`
+faulty.field=invalid_value
+name=FaultyService
+`)
+
+	var config FaultyConfig
+	err := Unmarshal(data, &config)
+	if err == nil {
+		t.Fatal("Expected Unmarshal to fail due to PropUnmarshaler error, but it did not")
+	}
+}


### PR DESCRIPTION
## Overview

This pull request enhances the `dotprops` package by introducing support for custom property marshaling and unmarshaling through the `PropMarshaler ` and `PropUnmarshaler` interfaces as well as `TextMarshaler` and `TextUnmarshaler` interfaces to provide more granular control over serialization and deserialization processes. Comprehensive updates to the documentation and an extensive suite of tests ensure robust functionality and ease of use.