### PR TITLE
Reduce complexity and satisfy linter rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: stable
 
       - name: Lint with golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           args: --timeout 5m
 
@@ -38,3 +38,49 @@ jobs:
       - name: Run tests
         run: |
           go test -v ./... -coverprofile=coverage.out
+
+      - name: Parse coverage
+        id: coverage
+        if: github.ref == 'refs/heads/main'
+        run: |
+          coverage="$(go tool cover -func=coverage.out | awk '/^total:/{print $3}')"
+          coverage_value="${coverage%\%}"
+          coverage_int="${coverage_value%.*}"
+          if [ -z "$coverage_int" ]; then
+            echo "Failed to parse coverage percentage." >&2
+            exit 1
+          fi
+          case "$coverage_int" in
+            9[5-9]|100) color="brightgreen" ;;
+            8[5-9]) color="green" ;;
+            7[0-9]) color="yellowgreen" ;;
+            5[0-9]) color="yellow" ;;
+            3[0-9]|4[0-9]) color="orange" ;;
+            *) color="red" ;;
+          esac
+          echo "coverage=$coverage" >> "$GITHUB_OUTPUT"
+          echo "color=$color" >> "$GITHUB_OUTPUT"
+
+      - name: Update badge
+        if: github.ref == 'refs/heads/main'
+        env:
+          SIGNUM_BADGE_ID: ${{ vars.SIGNUM_BADGE_ID }}
+          SIGNUM_BADGE_TOKEN: ${{ secrets.SIGNUM_BADGE_TOKEN }}
+          COVERAGE: ${{ steps.coverage.outputs.coverage }}
+          COLOR: ${{ steps.coverage.outputs.color }}
+        run: |
+          response="$(
+            curl -sS -X PATCH \
+              "https://signum.rhajizada.dev/api/badges/${SIGNUM_BADGE_ID}" \
+              -H 'accept: application/json' \
+              -H "Authorization: Bearer ${SIGNUM_BADGE_TOKEN}" \
+              -H 'Content-Type: application/json' \
+              -d "{\"color\":\"${COLOR}\",\"status\":\"${COVERAGE}\"}" \
+              -w "\n%{http_code}"
+          )"
+          http_body="$(echo "$response" | sed '$d')"
+          http_code="$(echo "$response" | tail -n 1)"
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "Badge update failed (${http_code}): ${http_body}" >&2
+            exit 1
+          fi

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,473 @@
+# This file is licensed under the terms of the MIT license https://opensource.org/license/mit
+# Copyright (c) 2021-2025 Marat Reymers
+
+## Golden config for golangci-lint v2.6.1
+#
+# This is the best config for golangci-lint based on my experience and opinion.
+# It is very strict, but not extremely strict.
+# Feel free to adapt it to suit your needs.
+# If this config helps you, please consider keeping a link to this file (see the next comment).
+
+# Based on https://gist.github.com/maratori/47a4d00457a92aa426dbd48a18776322
+
+version: "2"
+
+issues:
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 50
+
+formatters:
+  enable:
+    - goimports # checks if the code and import statements are formatted according to the 'goimports' command
+    - golines # checks if code is formatted, and fixes long lines
+
+    ## you may want to enable
+    #- gci # checks if code and import statements are formatted, with additional rules
+    #- gofmt # checks if the code is formatted according to 'gofmt' command
+    #- gofumpt # enforces a stricter format than 'gofmt', while being backwards compatible
+    #- swaggo # formats swaggo comments
+
+  # All settings can be found here https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml
+  settings:
+    goimports:
+      # A list of prefixes, which, if set, checks import paths
+      # with the given prefixes are grouped after 3rd-party packages.
+      # Default: []
+      local-prefixes:
+        - github.com/my/project
+
+    golines:
+      # Target maximum line length.
+      # Default: 100
+      max-len: 120
+
+linters:
+  enable:
+    - asasalint # checks for pass []any as any in variadic func(...any)
+    - asciicheck # checks that your code does not contain non-ASCII identifiers
+    - bidichk # checks for dangerous unicode character sequences
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - canonicalheader # checks whether net/http.Header uses canonical header
+    - copyloopvar # detects places where loop variables are copied (Go 1.22+)
+    - cyclop # checks function and package cyclomatic complexity
+    - depguard # checks if package imports are in a list of acceptable packages
+    - dupl # tool for code clone detection
+    - durationcheck # checks for two durations multiplied together
+    - embeddedstructfieldcheck # checks embedded types in structs
+    - errcheck # checking for unchecked errors, these unchecked errors can be critical bugs in some cases
+    - errname # checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error
+    - errorlint # finds code that will cause problems with the error wrapping scheme introduced in Go 1.13
+    - exhaustive # checks exhaustiveness of enum switch statements
+    - exptostd # detects functions from golang.org/x/exp/ that can be replaced by std functions
+    - fatcontext # detects nested contexts in loops
+    - forbidigo # forbids identifiers
+    - funcorder # checks the order of functions, methods, and constructors
+    - funlen # tool for detection of long functions
+    - gocheckcompilerdirectives # validates go compiler directive comments (//go:)
+    - gochecknoglobals # checks that no global variables exist
+    - gochecknoinits # checks that no init functions are present in Go code
+    - gochecksumtype # checks exhaustiveness on Go "sum types"
+    - gocognit # computes and checks the cognitive complexity of functions
+    - goconst # finds repeated strings that could be replaced by a constant
+    - gocritic # provides diagnostics that check for bugs, performance and style issues
+    - gocyclo # computes and checks the cyclomatic complexity of functions
+    - godoclint # checks Golang's documentation practice
+    - godot # checks if comments end in a period
+    - gomoddirectives # manages the use of 'replace', 'retract', and 'excludes' directives in go.mod
+    - goprintffuncname # checks that printf-like functions are named with f at the end
+    - gosec # inspects source code for security problems
+    - govet # reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - iface # checks the incorrect use of interfaces, helping developers avoid interface pollution
+    - ineffassign # detects when assignments to existing variables are not used
+    - intrange # finds places where for loops could make use of an integer range
+    - iotamixing # checks if iotas are being used in const blocks with other non-iota declarations
+    - loggercheck # checks key value pairs for common logger libraries (kitlog,klog,logr,zap)
+    - makezero # finds slice declarations with non-zero initial length
+    - mirror # reports wrong mirror patterns of bytes/strings usage
+    - mnd # detects magic numbers
+    - modernize # suggests simplifications to Go code, using modern language and library features
+    - musttag # enforces field tags in (un)marshaled structs
+    - nakedret # finds naked returns in functions greater than a specified function length
+    - nestif # reports deeply nested if statements
+    - nilerr # finds the code that returns nil even if it checks that the error is not nil
+    - nilnesserr # reports that it checks for err != nil, but it returns a different nil value error (powered by nilness and nilerr)
+    - nilnil # checks that there is no simultaneous return of nil error and an invalid value
+    - noctx # finds sending http request without context.Context
+    - nolintlint # reports ill-formed or insufficient nolint directives
+    - nonamedreturns # reports all named returns
+    - nosprintfhostport # checks for misuse of Sprintf to construct a host with port in a URL
+    - perfsprint # checks that fmt.Sprintf can be replaced with a faster alternative
+    - predeclared # finds code that shadows one of Go's predeclared identifiers
+    - promlinter # checks Prometheus metrics naming via promlint
+    - protogetter # reports direct reads from proto message fields when getters should be used
+    - reassign # checks that package variables are not reassigned
+    - recvcheck # checks for receiver type consistency
+    - revive # fast, configurable, extensible, flexible, and beautiful linter for Go, drop-in replacement of golint
+    - rowserrcheck # checks whether Err of rows is checked successfully
+    - sloglint # ensure consistent code style when using log/slog
+    - spancheck # checks for mistakes with OpenTelemetry/Census spans
+    - sqlclosecheck # checks that sql.Rows and sql.Stmt are closed
+    - staticcheck # is a go vet on steroids, applying a ton of static analysis checks
+    - testableexamples # checks if examples are testable (have an expected output)
+    - testifylint # checks usage of github.com/stretchr/testify
+    - testpackage # makes you use a separate _test package
+    - tparallel # detects inappropriate usage of t.Parallel() method in your Go test codes
+    - unconvert # removes unnecessary type conversions
+    - unparam # reports unused function parameters
+    - unqueryvet # detects SELECT * in SQL queries and SQL builders, encouraging explicit column selection
+    - unused # checks for unused constants, variables, functions and types
+    - usestdlibvars # detects the possibility to use variables/constants from the Go standard library
+    - usetesting # reports uses of functions with replacement inside the testing package
+    - wastedassign # finds wasted assignment statements
+    - whitespace # detects leading and trailing whitespace
+
+    ## you may want to enable
+    #- arangolint # opinionated best practices for arangodb client
+    #- decorder # checks declaration order and count of types, constants, variables and functions
+    #- exhaustruct # [highly recommend to enable] checks if all structure fields are initialized
+    #- ginkgolinter # [if you use ginkgo/gomega] enforces standards of using ginkgo and gomega
+    #- godox # detects usage of FIXME, TODO and other keywords inside comments
+    #- goheader # checks is file header matches to pattern
+    #- inamedparam # [great idea, but too strict, need to ignore a lot of cases by default] reports interfaces with unnamed method parameters
+    #- interfacebloat # checks the number of methods inside an interface
+    #- ireturn # accept interfaces, return concrete types
+    #- noinlineerr # disallows inline error handling `if err := ...; err != nil {`
+    #- prealloc # [premature optimization, but can be used in some cases] finds slice declarations that could potentially be preallocated
+    #- tagalign # checks that struct tags are well aligned
+    #- varnamelen # [great idea, but too many false positives] checks that the length of a variable's name matches its scope
+    #- wrapcheck # checks that errors returned from external packages are wrapped
+    #- zerologlint # detects the wrong usage of zerolog that a user forgets to dispatch zerolog.Event
+
+    ## disabled
+    #- containedctx # detects struct contained context.Context field
+    #- contextcheck # [too many false positives] checks the function whether use a non-inherited context
+    #- dogsled # checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
+    #- dupword # [useless without config] checks for duplicate words in the source code
+    #- err113 # [too strict] checks the errors handling expressions
+    #- errchkjson # [don't see profit + I'm against of omitting errors like in the first example https://github.com/breml/errchkjson] checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted
+    #- forcetypeassert # [replaced by errcheck] finds forced type assertions
+    #- gomodguard # [use more powerful depguard] allow and block lists linter for direct Go module dependencies
+    #- gosmopolitan # reports certain i18n/l10n anti-patterns in your Go codebase
+    #- grouper # analyzes expression groups
+    #- importas # enforces consistent import aliases
+    #- lll # [replaced by golines] reports long lines
+    #- maintidx # measures the maintainability index of each function
+    #- misspell # [useless] finds commonly misspelled English words in comments
+    #- nlreturn # [too strict and mostly code is not more readable] checks for a new line before return and branch statements to increase code clarity
+    #- paralleltest # [too many false positives] detects missing usage of t.Parallel() method in your Go test
+    #- tagliatelle # checks the struct tags
+    #- thelper # detects golang test helpers without t.Helper() call and checks the consistency of test helpers
+    #- wsl # [too strict and mostly code is not more readable] whitespace linter forces you to use empty lines
+    #- wsl_v5 # [too strict and mostly code is not more readable] add or remove empty lines
+
+  # All settings can be found here https://github.com/golangci/golangci-lint/blob/HEAD/.golangci.reference.yml
+  settings:
+    cyclop:
+      # The maximal code complexity to report.
+      # Default: 10
+      max-complexity: 30
+      # The maximal average package complexity.
+      # If it's higher than 0.0 (float) the check is enabled.
+      # Default: 0.0
+      package-average: 10.0
+
+    depguard:
+      # Rules to apply.
+      #
+      # Variables:
+      # - File Variables
+      #   Use an exclamation mark `!` to negate a variable.
+      #   Example: `!$test` matches any file that is not a go test file.
+      #
+      #   `$all` - matches all go files
+      #   `$test` - matches all go test files
+      #
+      # - Package Variables
+      #
+      #   `$gostd` - matches all of go's standard library (Pulled from `GOROOT`)
+      #
+      # Default (applies if no custom rules are defined): Only allow $gostd in all files.
+      rules:
+        "deprecated":
+          # List of file globs that will match this list of settings to compare against.
+          # By default, if a path is relative, it is relative to the directory where the golangci-lint command is executed.
+          # The placeholder '${base-path}' is substituted with a path relative to the mode defined with `run.relative-path-mode`.
+          # The placeholder '${config-path}' is substituted with a path relative to the configuration file.
+          # Default: $all
+          files:
+            - "$all"
+          # List of packages that are not allowed.
+          # Entries can be a variable (starting with $), a string prefix, or an exact match (if ending with $).
+          # Default: []
+          deny:
+            - pkg: github.com/golang/protobuf
+              desc: Use google.golang.org/protobuf instead, see https://developers.google.com/protocol-buffers/docs/reference/go/faq#modules
+            - pkg: github.com/satori/go.uuid
+              desc: Use github.com/google/uuid instead, satori's package is not maintained
+            - pkg: github.com/gofrs/uuid$
+              desc: Use github.com/gofrs/uuid/v5 or later, it was not a go module before v5
+        "non-test files":
+          files:
+            - "!$test"
+          deny:
+            - pkg: math/rand$
+              desc: Use math/rand/v2 instead, see https://go.dev/blog/randv2
+        "non-main files":
+          files:
+            - "!**/main.go"
+          deny:
+            - pkg: log$
+              desc: Use log/slog instead, see https://go.dev/blog/slog
+
+    embeddedstructfieldcheck:
+      # Checks that sync.Mutex and sync.RWMutex are not used as embedded fields.
+      # Default: false
+      forbid-mutex: true
+
+    errcheck:
+      # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+      # Such cases aren't reported by default.
+      # Default: false
+      check-type-assertions: true
+
+    exhaustive:
+      # Program elements to check for exhaustiveness.
+      # Default: [ switch ]
+      check:
+        - switch
+        - map
+
+    exhaustruct:
+      # List of regular expressions to match type names that should be excluded from processing.
+      # Anonymous structs can be matched by '<anonymous>' alias.
+      # Has precedence over `include`.
+      # Each regular expression must match the full type name, including package path.
+      # For example, to match type `net/http.Cookie` regular expression should be `.*/http\.Cookie`,
+      # but not `http\.Cookie`.
+      # Default: []
+      exclude:
+        # std libs
+        - ^net/http.Client$
+        - ^net/http.Cookie$
+        - ^net/http.Request$
+        - ^net/http.Response$
+        - ^net/http.Server$
+        - ^net/http.Transport$
+        - ^net/url.URL$
+        - ^os/exec.Cmd$
+        - ^reflect.StructField$
+        # public libs
+        - ^github.com/Shopify/sarama.Config$
+        - ^github.com/Shopify/sarama.ProducerMessage$
+        - ^github.com/mitchellh/mapstructure.DecoderConfig$
+        - ^github.com/prometheus/client_golang/.+Opts$
+        - ^github.com/spf13/cobra.Command$
+        - ^github.com/spf13/cobra.CompletionOptions$
+        - ^github.com/stretchr/testify/mock.Mock$
+        - ^github.com/testcontainers/testcontainers-go.+Request$
+        - ^github.com/testcontainers/testcontainers-go.FromDockerfile$
+        - ^golang.org/x/tools/go/analysis.Analyzer$
+        - ^google.golang.org/protobuf/.+Options$
+        - ^gopkg.in/yaml.v3.Node$
+      # Allows empty structures in return statements.
+      # Default: false
+      allow-empty-returns: true
+
+    funcorder:
+      # Checks if the exported methods of a structure are placed before the non-exported ones.
+      # Default: true
+      struct-method: false
+
+    funlen:
+      # Checks the number of lines in a function.
+      # If lower than 0, disable the check.
+      # Default: 60
+      lines: 100
+      # Checks the number of statements in a function.
+      # If lower than 0, disable the check.
+      # Default: 40
+      statements: 50
+
+    gochecksumtype:
+      # Presence of `default` case in switch statements satisfies exhaustiveness, if all members are not listed.
+      # Default: true
+      default-signifies-exhaustive: false
+
+    gocognit:
+      # Minimal code complexity to report.
+      # Default: 30 (but we recommend 10-20)
+      min-complexity: 20
+
+    gocritic:
+      # Settings passed to gocritic.
+      # The settings key is the name of a supported gocritic checker.
+      # The list of supported checkers can be found at https://go-critic.com/overview.
+      settings:
+        captLocal:
+          # Whether to restrict checker to params only.
+          # Default: true
+          paramsOnly: false
+        underef:
+          # Whether to skip (*x).method() calls where x is a pointer receiver.
+          # Default: true
+          skipRecvDeref: false
+
+    godoclint:
+      # List of rules to enable in addition to the default set.
+      # Default: empty
+      enable:
+        # Assert no unused link in godocs.
+        # https://github.com/godoc-lint/godoc-lint?tab=readme-ov-file#no-unused-link
+        - no-unused-link
+
+    govet:
+      # Enable all analyzers.
+      # Default: false
+      enable-all: true
+      # Disable analyzers by name.
+      # Run `GL_DEBUG=govet golangci-lint run --enable=govet` to see default, all available analyzers, and enabled analyzers.
+      # Default: []
+      disable:
+        - fieldalignment # too strict
+      # Settings per analyzer.
+      settings:
+        shadow:
+          # Whether to be strict about shadowing; can be noisy.
+          # Default: false
+          strict: true
+
+    inamedparam:
+      # Skips check for interface methods with only a single parameter.
+      # Default: false
+      skip-single-param: true
+
+    mnd:
+      # List of function patterns to exclude from analysis.
+      # Values always ignored: `time.Date`,
+      # `strconv.FormatInt`, `strconv.FormatUint`, `strconv.FormatFloat`,
+      # `strconv.ParseInt`, `strconv.ParseUint`, `strconv.ParseFloat`.
+      # Default: []
+      ignored-functions:
+        - args.Error
+        - flag.Arg
+        - flag.Duration.*
+        - flag.Float.*
+        - flag.Int.*
+        - flag.Uint.*
+        - os.Chmod
+        - os.Mkdir.*
+        - os.OpenFile
+        - os.WriteFile
+        - prometheus.ExponentialBuckets.*
+        - prometheus.LinearBuckets
+
+    nakedret:
+      # Make an issue if func has more lines of code than this setting, and it has naked returns.
+      # Default: 30
+      max-func-lines: 0
+
+    nolintlint:
+      # Exclude following linters from requiring an explanation.
+      # Default: []
+      allow-no-explanation: [funlen, gocognit, golines]
+      # Enable to require an explanation of nonzero length after each nolint directive.
+      # Default: false
+      require-explanation: true
+      # Enable to require nolint directives to mention the specific linter being suppressed.
+      # Default: false
+      require-specific: true
+
+    perfsprint:
+      # Optimizes into strings concatenation.
+      # Default: true
+      strconcat: false
+
+    reassign:
+      # Patterns for global variable names that are checked for reassignment.
+      # See https://github.com/curioswitch/go-reassign#usage
+      # Default: ["EOF", "Err.*"]
+      patterns:
+        - ".*"
+
+    rowserrcheck:
+      # database/sql is always checked.
+      # Default: []
+      packages:
+        - github.com/jmoiron/sqlx
+
+    sloglint:
+      # Enforce not using global loggers.
+      # Values:
+      # - "": disabled
+      # - "all": report all global loggers
+      # - "default": report only the default slog logger
+      # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-global
+      # Default: ""
+      no-global: all
+      # Enforce using methods that accept a context.
+      # Values:
+      # - "": disabled
+      # - "all": report all contextless calls
+      # - "scope": report only if a context exists in the scope of the outermost function
+      # https://github.com/go-simpler/sloglint?tab=readme-ov-file#context-only
+      # Default: ""
+      context: scope
+
+    staticcheck:
+      # SAxxxx checks in https://staticcheck.dev/docs/configuration/options/#checks
+      # Example (to disable some checks): [ "all", "-SA1000", "-SA1001"]
+      # Default: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+      checks:
+        - all
+        # Incorrect or missing package comment.
+        # https://staticcheck.dev/docs/checks/#ST1000
+        - -ST1000
+        # Use consistent method receiver names.
+        # https://staticcheck.dev/docs/checks/#ST1016
+        - -ST1016
+        # Omit embedded fields from selector expression.
+        # https://staticcheck.dev/docs/checks/#QF1008
+        - -QF1008
+
+    usetesting:
+      # Enable/disable `os.TempDir()` detections.
+      # Default: false
+      os-temp-dir: true
+
+  exclusions:
+    # Log a warning if an exclusion rule is unused.
+    # Default: false
+    warn-unused: true
+    # Predefined exclusion rules.
+    # Default: []
+    presets:
+      - std-error-handling
+      - common-false-positives
+    # Excluding configuration per-path, per-linter, per-text and per-source.
+    rules:
+      - source: "TODO"
+        linters: [godot]
+      - text: "should have a package comment"
+        linters: [revive]
+      - text: 'exported \S+ \S+ should have comment( \(or a comment on this block\))? or be unexported'
+        linters: [revive]
+      - text: 'package comment should be of the form ".+"'
+        source: "// ?(nolint|TODO)"
+        linters: [revive]
+      - text: 'comment on exported \S+ \S+ should be of the form ".+"'
+        source: "// ?(nolint|TODO)"
+        linters: [revive, staticcheck]
+      - path: '_test\.go'
+        linters:
+          - bodyclose
+          - dupl
+          - errcheck
+          - funlen
+          - goconst
+          - gosec
+          - noctx
+          - wrapcheck
+    paths:
+      - docs

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-export PATH := $(HOME)/go/bin:$(PATH)
+.DEFAULT_GOAL := help
+PKGS ?= ./...
 
 .PHONY: all
-## all: Default target - runs fmt, vet, lint, staticcheck, and test.
-all: fmt vet lint staticcheck test
+## all: Runs fmt, vet, lint, staticcheck, test, and coverage.
+all: fmt vet lint staticcheck test coverage
 
 .PHONY: fmt
 ## fmt: Formats the code using go fmt.
@@ -35,12 +36,23 @@ staticcheck:
 .PHONY: test
 ## test: Runs all tests using go test.
 test:
-	@go test ./...
+	@go test $(PKGS)
+
+.PHONY: coverage
+## coverage: Generate test coverage report (uses gotestsum if available).
+coverage:
+	@if ! [ -x "$$(which gotestsum)" ]; then \
+		echo "gotestsum not found, installing..."; \
+		go install gotest.tools/gotestsum@latest; \
+	fi
+	@gotestsum -- -coverprofile=coverage.out $(PKGS)
+	@go tool cover -func=coverage.out
 
 .PHONY: help
-## help: Show help message
+## help: Show help message.
 help: Makefile
 	@echo
 	@echo " Available targets:"
 	@echo
 	@sed -n 's/^## //p' $< | column -t -s ':' | sed -e 's/^/  /'
+

--- a/README.md
+++ b/README.md
@@ -673,3 +673,8 @@ custom.field=value1_42
     fmt.Printf("CustomField: %+v\n", config.CustomField)
 }
 ```
+
+## Contribute
+
+- Issues and forks are welcome.
+- PRs are welcome; require maintainer review before merge.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # dotprops
 
-![ci](https://github.com/rhajizada/dotprops/actions/workflows/ci.yml/badge.svg)
 ![Go](https://img.shields.io/badge/Go-1.22-blue.svg)
+[![Go Reference](https://pkg.go.dev/badge/github.com/rhajizada/dotprops.svg)](https://pkg.go.dev/github.com/rhajizada/dotprops)
 ![License](https://img.shields.io/badge/License-MIT-green.svg)
-
+![ci](https://github.com/rhajizada/dotprops/actions/workflows/ci.yml/badge.svg)
+![coverage](https://signum.rhajizada.dev/api/badges/5e139b14-f6ee-4dd4-ae50-861fb2a328bd)
 
 dotprops is a `Go` package for marshalling and unmarshalling `Java` `.properties`
 files into structs, similar to how the `encoding/json` package works.
@@ -672,4 +673,3 @@ custom.field=value1_42
     fmt.Printf("CustomField: %+v\n", config.CustomField)
 }
 ```
-

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -160,6 +160,6 @@ type FaultyPropUnmarshaller struct {
 	Field2 int
 }
 
-func (f *FaultyPropUnmarshaller) UnmarshalProp(key string, value string) error {
+func (f *FaultyPropUnmarshaller) UnmarshalProp(_ string, _ string) error {
 	return errors.New("unmarshaling error")
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,4 +1,4 @@
-package dotprops
+package dotprops_test
 
 import (
 	"errors"
@@ -55,11 +55,11 @@ type EndpointConfig struct {
 
 // Custom Types Implementing Interfaces for Testing
 
-// CustomString implements TextMarshaler and TextUnmarshaler
+// CustomString implements TextMarshaler and TextUnmarshaler.
 type CustomString string
 
 func (cs CustomString) MarshalText() ([]byte, error) {
-	return []byte(fmt.Sprintf("custom_%s", cs)), nil
+	return fmt.Appendf(nil, "custom_%s", cs), nil
 }
 
 func (cs *CustomString) UnmarshalText(text []byte) error {
@@ -70,11 +70,11 @@ func (cs *CustomString) UnmarshalText(text []byte) error {
 	return nil
 }
 
-// CustomInt implements TextMarshaler and TextUnmarshaler
+// CustomInt implements TextMarshaler and TextUnmarshaler.
 type CustomInt int
 
 func (ci CustomInt) MarshalText() ([]byte, error) {
-	return []byte(fmt.Sprintf("custom_%d", ci)), nil
+	return fmt.Appendf(nil, "custom_%d", ci), nil
 }
 
 func (ci *CustomInt) UnmarshalText(text []byte) error {
@@ -90,11 +90,11 @@ func (ci *CustomInt) UnmarshalText(text []byte) error {
 	return nil
 }
 
-// CustomFloat implements TextMarshaler and TextUnmarshaler
+// CustomFloat implements TextMarshaler and TextUnmarshaler.
 type CustomFloat float64
 
 func (cf CustomFloat) MarshalText() ([]byte, error) {
-	return []byte(fmt.Sprintf("custom_%.2f", cf)), nil
+	return fmt.Appendf(nil, "custom_%.2f", cf), nil
 }
 
 func (cf *CustomFloat) UnmarshalText(text []byte) error {
@@ -121,7 +121,7 @@ func (c CustomPropMarshaller) MarshalProp() (string, string, error) {
 	return key, value, nil
 }
 
-// CustomPropUnmarshaller implements PropUnmarshaler
+// CustomPropUnmarshaller implements PropUnmarshaler.
 type CustomPropUnmarshaller struct {
 	Field1 string
 	Field2 int

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,11 +1,11 @@
 package dotprops
 
-// TextMarshaler interface as defined in the encoding package
+// TextMarshaler interface as defined in the encoding package.
 type TextMarshaler interface {
 	MarshalText() (text []byte, err error)
 }
 
-// TextUnmarshaler interface as defined in the encoding package
+// TextUnmarshaler interface as defined in the encoding package.
 type TextUnmarshaler interface {
 	UnmarshalText(text []byte) error
 }

--- a/marshal.go
+++ b/marshal.go
@@ -1,28 +1,30 @@
 package dotprops
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 )
 
 // Marshal returns the properties encoding of v.
 // v must be a struct or a pointer to a struct.
-func Marshal(v interface{}) ([]byte, error) {
+func Marshal(v any) ([]byte, error) {
 	val := reflect.ValueOf(v)
 	if val.Kind() == reflect.Ptr {
 		if val.Elem().Kind() != reflect.Struct {
-			return nil, fmt.Errorf("marshal expects a pointer to a struct")
+			return nil, errors.New("marshal expects a pointer to a struct")
 		}
 		val = val.Elem()
 	} else if val.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("marshal expects a struct or a pointer to a struct")
+		return nil, errors.New("marshal expects a struct or a pointer to a struct")
 	}
 
 	// Ensure the value is addressable
 	if !val.CanAddr() {
-		return nil, fmt.Errorf("marshal requires an addressable struct to handle TextMarshaler")
+		return nil, errors.New("marshal requires an addressable struct to handle TextMarshaler")
 	}
 
 	props := make(map[string]string)
@@ -47,7 +49,7 @@ func Marshal(v interface{}) ([]byte, error) {
 	return []byte(sb.String()), nil
 }
 
-// encodeStruct encodes a struct into the props map with proper key prefixes
+// encodeStruct encodes a struct into the props map with proper key prefixes.
 func encodeStruct(prefix string, val reflect.Value, props map[string]string) error {
 	valType := val.Type()
 
@@ -60,24 +62,7 @@ func encodeStruct(prefix string, val reflect.Value, props map[string]string) err
 			continue
 		}
 
-		// Check if the field is embedded
-		isEmbedded := fieldType.Anonymous
-
-		// Get the property key from the struct tag or use the field name
-		propertyKey := fieldType.Tag.Get("property")
-		if propertyKey == "" && !isEmbedded {
-			propertyKey = fieldType.Name
-		}
-
-		var fullKey string
-		if isEmbedded {
-			// Do not add propertyKey as prefix; use the current prefix
-			fullKey = prefix
-		} else if prefix != "" {
-			fullKey = prefix + "." + propertyKey
-		} else {
-			fullKey = propertyKey
-		}
+		fullKey, _ := fieldKey(prefix, fieldType)
 
 		// Handle pointer types
 		if field.Kind() == reflect.Ptr {
@@ -87,57 +72,105 @@ func encodeStruct(prefix string, val reflect.Value, props map[string]string) err
 			field = field.Elem()
 		}
 
-		// Check if the field implements PropMarshaler
-		if pm, ok := field.Addr().Interface().(PropMarshaler); ok {
-			key, value, err := pm.MarshalProp()
+		if handled, err := marshalPropField(field, fullKey, props); handled {
 			if err != nil {
-				return fmt.Errorf("error marshaling field '%s': %v", fullKey, err)
+				return err
 			}
-			props[key] = value
 			continue
 		}
 
-		// Check if the field implements TextMarshaler
-		if field.CanInterface() {
-			if marshaler, ok := field.Addr().Interface().(TextMarshaler); ok {
-				text, err := marshaler.MarshalText()
-				if err != nil {
-					return fmt.Errorf("error marshaling field '%s': %v", fullKey, err)
-				}
-				props[fullKey] = string(text)
-				continue
+		if handled, err := marshalTextField(field, fullKey, props); handled {
+			if err != nil {
+				return err
 			}
+			continue
 		}
 
-		switch field.Kind() {
-		case reflect.Struct:
-			if isEmbedded {
-				// For embedded structs, continue with the same prefix
-				err := encodeStruct(fullKey, field, props)
-				if err != nil {
-					return err
-				}
-			} else {
-				// For nested structs, use the new prefix
-				err := encodeStruct(fullKey, field, props)
-				if err != nil {
-					return err
-				}
-			}
-		case reflect.String:
-			props[fullKey] = field.String()
-		case reflect.Bool:
-			props[fullKey] = fmt.Sprintf("%v", field.Bool())
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-			props[fullKey] = fmt.Sprintf("%d", field.Int())
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-			props[fullKey] = fmt.Sprintf("%d", field.Uint())
-		case reflect.Float32, reflect.Float64:
-			props[fullKey] = fmt.Sprintf("%f", field.Float())
-		default:
-			return fmt.Errorf("unsupported field type: %s for field %s", field.Kind(), fullKey)
+		if err := encodeFieldValue(fullKey, field, props); err != nil {
+			return err
 		}
 	}
 
+	return nil
+}
+
+func fieldKey(prefix string, fieldType reflect.StructField) (string, bool) {
+	isEmbedded := fieldType.Anonymous
+	propertyKey := fieldType.Tag.Get("property")
+	if propertyKey == "" && !isEmbedded {
+		propertyKey = fieldType.Name
+	}
+
+	switch {
+	case isEmbedded:
+		return prefix, true
+	case prefix != "":
+		return prefix + "." + propertyKey, false
+	default:
+		return propertyKey, false
+	}
+}
+
+func marshalPropField(field reflect.Value, fullKey string, props map[string]string) (bool, error) {
+	if !field.CanInterface() {
+		return false, nil
+	}
+
+	if pm, ok := field.Addr().Interface().(PropMarshaler); ok {
+		key, value, err := pm.MarshalProp()
+		if err != nil {
+			return true, fmt.Errorf("error marshaling field '%s': %w", fullKey, err)
+		}
+		props[key] = value
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func marshalTextField(field reflect.Value, fullKey string, props map[string]string) (bool, error) {
+	if !field.CanInterface() {
+		return false, nil
+	}
+
+	if marshaler, ok := field.Addr().Interface().(TextMarshaler); ok {
+		text, err := marshaler.MarshalText()
+		if err != nil {
+			return true, fmt.Errorf("error marshaling field '%s': %w", fullKey, err)
+		}
+		props[fullKey] = string(text)
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func encodeFieldValue(fullKey string, field reflect.Value, props map[string]string) error {
+	switch field.Kind() {
+	case reflect.Struct:
+		return encodeStruct(fullKey, field, props)
+	case reflect.String:
+		props[fullKey] = field.String()
+	case reflect.Bool:
+		props[fullKey] = strconv.FormatBool(field.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		props[fullKey] = strconv.FormatInt(field.Int(), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		props[fullKey] = strconv.FormatUint(field.Uint(), 10)
+	case reflect.Float32, reflect.Float64:
+		props[fullKey] = fmt.Sprintf("%f", field.Float())
+	case reflect.Invalid,
+		reflect.Complex64,
+		reflect.Complex128,
+		reflect.Array,
+		reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Ptr,
+		reflect.Slice,
+		reflect.UnsafePointer:
+		return fmt.Errorf("unsupported field type: %s for field %s", field.Kind(), fullKey)
+	}
 	return nil
 }

--- a/marshal.go
+++ b/marshal.go
@@ -53,7 +53,7 @@ func Marshal(v any) ([]byte, error) {
 func encodeStruct(prefix string, val reflect.Value, props map[string]string) error {
 	valType := val.Type()
 
-	for i := 0; i < val.NumField(); i++ {
+	for i := range val.NumField() {
 		field := val.Field(i)
 		fieldType := valType.Field(i)
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1,8 +1,10 @@
-package dotprops
+package dotprops_test
 
 import (
 	"errors"
 	"testing"
+
+	"github.com/rhajizada/dotprops"
 )
 
 func TestMarshalSimple(t *testing.T) {
@@ -14,7 +16,7 @@ func TestMarshalSimple(t *testing.T) {
 
 	expected := "app.debug=false\napp.name=TestApp\napp.port=3000\n"
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -37,7 +39,7 @@ func TestMarshalNested(t *testing.T) {
 
 	expected := "app.name=MyApp\ndatabase.host=localhost\ndatabase.password=secret\ndatabase.port=5432\ndatabase.username=admin\n"
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -58,7 +60,7 @@ func TestMarshalOptionalFields(t *testing.T) {
 
 	expected := "app.debug=true\napp.name=MyApp\n"
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -77,7 +79,7 @@ func TestMarshalUnsupportedType(t *testing.T) {
 		Data: []string{"one", "two", "three"},
 	}
 
-	_, err := Marshal(config)
+	_, err := dotprops.Marshal(config)
 	if err == nil {
 		t.Fatal("Expected error for unsupported type, got nil")
 	}
@@ -90,7 +92,7 @@ func TestMarshalNilPointer(t *testing.T) {
 		Debug:   nil,
 	}
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -105,7 +107,7 @@ func TestMarshalEmptyStruct(t *testing.T) {
 
 	config := &EmptyStruct{}
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -118,7 +120,7 @@ func TestMarshalEmptyStruct(t *testing.T) {
 func TestMarshalNonStruct(t *testing.T) {
 	nonStruct := "I am not a struct"
 
-	_, err := Marshal(nonStruct)
+	_, err := dotprops.Marshal(nonStruct)
 	if err == nil {
 		t.Fatal("Expected error for non-struct input, got nil")
 	}
@@ -139,7 +141,7 @@ func TestMarshalWithTextMarshaler(t *testing.T) {
 
 	expected := "count=custom_42\nname=custom_example\n"
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -151,7 +153,7 @@ func TestMarshalWithTextMarshaler(t *testing.T) {
 
 type FaultyCustomString string
 
-// Implement TextMarshaler that returns an error
+// Implement TextMarshaler that returns an error.
 func (fcs FaultyCustomString) MarshalText() ([]byte, error) {
 	return nil, errors.New("marshal error")
 }
@@ -164,7 +166,7 @@ func TestMarshalWithTextMarshalerError(t *testing.T) {
 	config := &ErrorConfig{
 		Name: "faulty",
 	}
-	_, err := Marshal(config)
+	_, err := dotprops.Marshal(config)
 	if err == nil {
 		t.Fatal("Expected Marshal to fail due to TextMarshaler error, but it did not")
 	}
@@ -185,7 +187,7 @@ func TestMarshalWithUintAndFloatFields(t *testing.T) {
 
 	expected := "max.users=1000\nthreshold=75.500000\n"
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -209,7 +211,7 @@ func TestMarshalWithMultiLevelNestedStruct(t *testing.T) {
 
 	expected := "service.endpoint.active=true\nservice.endpoint.port=443\nservice.endpoint.url=https://auth.example.com\nservice.name=AuthService\n"
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -226,6 +228,7 @@ func TestMarshalWithEmbeddedStruct(t *testing.T) {
 
 	type EmbeddedConfig struct {
 		BaseConfig
+
 		Name string `property:"name"`
 	}
 
@@ -238,7 +241,7 @@ func TestMarshalWithEmbeddedStruct(t *testing.T) {
 
 	expected := "name=EmbeddedService\nversion=1.0.0\n"
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -265,7 +268,7 @@ func TestMarshalWithUnsupportedNestedStruct(t *testing.T) {
 		},
 	}
 
-	_, err := Marshal(config)
+	_, err := dotprops.Marshal(config)
 	if err == nil {
 		t.Fatal("Expected Marshal to fail due to unsupported nested struct field type, but it did not")
 	}
@@ -281,6 +284,7 @@ func TestMarshalWithMultipleEmbeddedStructs(t *testing.T) {
 	type EmbeddedConfig struct {
 		BaseConfig
 		SecurityConfig
+
 		Name string `property:"name"`
 	}
 
@@ -296,7 +300,7 @@ func TestMarshalWithMultipleEmbeddedStructs(t *testing.T) {
 
 	expected := "enabled=true\nname=MultiEmbeddedService\nversion=2.0.0\n"
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -312,6 +316,7 @@ func TestMarshalWithPointerEmbeddedStructs(t *testing.T) {
 	}
 	type EmbeddedConfig struct {
 		*BaseConfig
+
 		Name string `property:"name"`
 	}
 
@@ -324,7 +329,7 @@ func TestMarshalWithPointerEmbeddedStructs(t *testing.T) {
 
 	expected := "name=PointerEmbeddedService\nversion=3.1.4\n"
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -346,7 +351,7 @@ func TestMarshalWithCustomTextMarshaler(t *testing.T) {
 
 	expected := "count=custom_100\nname=custom_example\n"
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -372,7 +377,7 @@ func TestMarshalWithUnsupportedNestedStructTypes(t *testing.T) {
 		},
 	}
 
-	_, err := Marshal(config)
+	_, err := dotprops.Marshal(config)
 	if err == nil {
 		t.Fatal("Expected Marshal to fail due to unsupported nested struct field type, but it did not")
 	}
@@ -408,7 +413,7 @@ func TestMarshalWithMultipleLevelsNestedStructs(t *testing.T) {
 
 	expected := "active=true\nlevel1.level2.level3.key=deep_value\nname=DeepNestedService\n"
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -424,6 +429,7 @@ func TestMarshalWithMissingEmbeddedStructFields(t *testing.T) {
 	}
 	type EmbeddedConfig struct {
 		BaseConfig
+
 		Name string `property:"name"`
 	}
 
@@ -436,7 +442,7 @@ func TestMarshalWithMissingEmbeddedStructFields(t *testing.T) {
 
 	expected := "name=EmbeddedService\nversion=\n"
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -462,7 +468,7 @@ func TestMarshalWithExtraProperties(t *testing.T) {
 
 	expected := "age=45\nname=ExtraService\n"
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -472,7 +478,7 @@ func TestMarshalWithExtraProperties(t *testing.T) {
 	}
 }
 
-// TestMarshalWithPropMarshaler tests marshalling with PropMarshaler interface
+// TestMarshalWithPropMarshaler tests marshalling with PropMarshaler interface.
 func TestMarshalWithPropMarshaler(t *testing.T) {
 	type CustomConfig struct {
 		CustomField CustomPropMarshaller `property:"custom.field"`
@@ -489,7 +495,7 @@ func TestMarshalWithPropMarshaler(t *testing.T) {
 
 	expected := "custom.field=value1_42\nname=TestService\n"
 
-	data, err := Marshal(config)
+	data, err := dotprops.Marshal(config)
 	if err != nil {
 		t.Fatalf("Marshal failed: %v", err)
 	}
@@ -499,15 +505,14 @@ func TestMarshalWithPropMarshaler(t *testing.T) {
 	}
 }
 
-// TestMarshalWithPropMarshalerError tests marshalling when PropMarshaler returns an error
+// TestMarshalWithPropMarshalerError tests marshalling when PropMarshaler returns an error.
 func TestMarshalWithPropMarshalerError(t *testing.T) {
-
 	config := &FaultyConfig{
 		FaultyField: FaultyPropMarshaller{},
 		Name:        "FaultyService",
 	}
 
-	_, err := Marshal(config)
+	_, err := dotprops.Marshal(config)
 	if err == nil {
 		t.Fatal("Expected Marshal to fail due to PropMarshaler error, but it did not")
 	}

--- a/properties.go
+++ b/properties.go
@@ -33,7 +33,7 @@ func parseProperties(data []byte) (map[string]any, error) {
 			keyList := strings.Split(key, ".")
 
 			current := props
-			for i := 0; i < len(keyList)-1; i++ {
+			for i := range len(keyList) - 1 {
 				k := keyList[i]
 				if _, ok := current[k]; !ok {
 					current[k] = make(map[string]any)
@@ -86,7 +86,7 @@ func getNestedProperty(props map[string]any, key string) (any, bool) {
 func setStructFields(structVal reflect.Value, props map[string]any) error {
 	structType := structVal.Type()
 
-	for i := 0; i < structVal.NumField(); i++ {
+	for i := range structVal.NumField() {
 		field := structVal.Field(i)
 		fieldType := structType.Field(i)
 
@@ -102,11 +102,6 @@ func setStructFields(structVal reflect.Value, props map[string]any) error {
 
 	return nil
 }
-
-var (
-	propUnmarshallerType = reflect.TypeOf((*PropUnmarshaller)(nil)).Elem()
-	textUnmarshallerType = reflect.TypeOf((*TextUnmarshaler)(nil)).Elem()
-)
 
 func setStructField(field reflect.Value, fieldType reflect.StructField, props map[string]any) error {
 	if fieldType.Anonymous {
@@ -138,9 +133,34 @@ func setEmbeddedStructField(field reflect.Value, props map[string]any) error {
 			field.Set(reflect.New(field.Type().Elem()))
 		}
 		return setStructFields(field.Elem(), props)
-	default:
+	case reflect.Invalid,
+		reflect.Bool,
+		reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64,
+		reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64,
+		reflect.Uintptr,
+		reflect.Float32,
+		reflect.Float64,
+		reflect.Complex64,
+		reflect.Complex128,
+		reflect.Array,
+		reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Slice,
+		reflect.String,
+		reflect.UnsafePointer:
 		return nil
 	}
+	return nil
 }
 
 func applyFieldValue(field reflect.Value, propertyKey string, value any) error {
@@ -166,6 +186,7 @@ func applyFieldValue(field reflect.Value, propertyKey string, value any) error {
 }
 
 func applyPropUnmarshaller(field reflect.Value, propertyKey string, value any) (bool, error) {
+	propUnmarshallerType := reflect.TypeFor[PropUnmarshaller]()
 	target, ok := interfaceValue(field, propUnmarshallerType)
 	if !ok {
 		return false, nil
@@ -176,13 +197,13 @@ func applyPropUnmarshaller(field reflect.Value, propertyKey string, value any) (
 		return false, nil
 	}
 
-	key, valStr, err := extractKeyValue(propertyKey, value)
-	if err != nil {
-		return true, fmt.Errorf("error extracting key-value for field '%s': %w", propertyKey, err)
+	key, valStr, extractErr := extractKeyValue(propertyKey, value)
+	if extractErr != nil {
+		return true, fmt.Errorf("error extracting key-value for field '%s': %w", propertyKey, extractErr)
 	}
 
-	if err := unmarshaler.UnmarshalProp(key, valStr); err != nil {
-		return true, fmt.Errorf("error unmarshaling field '%s': %w", propertyKey, err)
+	if unmarshalErr := unmarshaler.UnmarshalProp(key, valStr); unmarshalErr != nil {
+		return true, fmt.Errorf("error unmarshaling field '%s': %w", propertyKey, unmarshalErr)
 	}
 	return true, nil
 }
@@ -207,12 +228,38 @@ func applyNestedStruct(field reflect.Value, propertyKey string, value any) (bool
 			field.Set(reflect.New(field.Type().Elem()))
 		}
 		return true, setStructFields(field.Elem(), subProps)
-	default:
+	case reflect.Invalid,
+		reflect.Bool,
+		reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64,
+		reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64,
+		reflect.Uintptr,
+		reflect.Float32,
+		reflect.Float64,
+		reflect.Complex64,
+		reflect.Complex128,
+		reflect.Array,
+		reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Slice,
+		reflect.String,
+		reflect.UnsafePointer:
 		return false, nil
 	}
+	return false, nil
 }
 
 func applyTextUnmarshaller(field reflect.Value, propertyKey string, value any) (bool, error) {
+	textUnmarshallerType := reflect.TypeFor[TextUnmarshaler]()
 	target, ok := interfaceValue(field, textUnmarshallerType)
 	if !ok {
 		return false, nil

--- a/properties.go
+++ b/properties.go
@@ -10,8 +10,8 @@ import (
 )
 
 // parseProperties reads properties data and returns a map of key-value pairs.
-func parseProperties(data []byte) (map[string]interface{}, error) {
-	props := make(map[string]interface{})
+func parseProperties(data []byte) (map[string]any, error) {
+	props := make(map[string]any)
 	scanner := bufio.NewScanner(strings.NewReader(string(data)))
 	pattern := regexp.MustCompile("^([^#][^=]*)=(.*)")
 
@@ -36,10 +36,10 @@ func parseProperties(data []byte) (map[string]interface{}, error) {
 			for i := 0; i < len(keyList)-1; i++ {
 				k := keyList[i]
 				if _, ok := current[k]; !ok {
-					current[k] = make(map[string]interface{})
+					current[k] = make(map[string]any)
 				}
 				// Type assertion to navigate deeper into the nested map
-				if nextMap, ok := current[k].(map[string]interface{}); ok {
+				if nextMap, ok := current[k].(map[string]any); ok {
 					current = nextMap
 				} else {
 					// Handle type mismatch if the existing key is not a map
@@ -64,12 +64,12 @@ func parseProperties(data []byte) (map[string]interface{}, error) {
 }
 
 // getNestedProperty traverses the nested map to retrieve the value for a dot-separated key.
-func getNestedProperty(props map[string]interface{}, key string) (interface{}, bool) {
+func getNestedProperty(props map[string]any, key string) (any, bool) {
 	parts := strings.Split(key, ".")
-	var current interface{} = props
+	var current any = props
 	for _, part := range parts {
 		switch currMap := current.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			var ok bool
 			current, ok = currMap[part]
 			if !ok {
@@ -83,7 +83,7 @@ func getNestedProperty(props map[string]interface{}, key string) (interface{}, b
 }
 
 // setStructFields sets the fields of the struct based on the provided properties.
-func setStructFields(structVal reflect.Value, props map[string]interface{}) error {
+func setStructFields(structVal reflect.Value, props map[string]any) error {
 	structType := structVal.Type()
 
 	for i := 0; i < structVal.NumField(); i++ {
@@ -95,108 +95,176 @@ func setStructFields(structVal reflect.Value, props map[string]interface{}) erro
 			continue
 		}
 
-		// Check if the field is embedded (anonymous)
-		if fieldType.Anonymous {
-			// Handle embedded struct: pass the same props map
-			if field.Kind() == reflect.Struct {
-				err := setStructFields(field, props)
-				if err != nil {
-					return err
-				}
-			} else if field.Kind() == reflect.Ptr && field.Type().Elem().Kind() == reflect.Struct {
-				if field.IsNil() {
-					field.Set(reflect.New(field.Type().Elem()))
-				}
-				err := setStructFields(field.Elem(), props)
-				if err != nil {
-					return err
-				}
-			}
-			continue
-		}
-
-		// Get the property key from the struct tag or use the field name
-		propertyKey := fieldType.Tag.Get("property")
-		if propertyKey == "" {
-			propertyKey = fieldType.Name
-		}
-
-		// Retrieve the value using the helper function
-		value, ok := getNestedProperty(props, propertyKey)
-		if !ok {
-			continue // Property not found in data
-		}
-
-		// Check if the field implements PropUnmarshaler
-		if pu, ok := field.Addr().Interface().(PropUnmarshaller); ok {
-			key, valStr, err := extractKeyValue(propertyKey, value)
-			if err != nil {
-				return fmt.Errorf("error extracting key-value for field '%s': %v", propertyKey, err)
-			}
-			err = pu.UnmarshalProp(key, valStr)
-			if err != nil {
-				return fmt.Errorf("error unmarshaling field '%s': %v", propertyKey, err)
-			}
-			continue
-		}
-
-		// Handle nested structs
-		if field.Kind() == reflect.Struct {
-			// The properties should be nested under propertyKey
-			if subProps, ok := value.(map[string]interface{}); ok {
-				err := setStructFields(field, subProps)
-				if err != nil {
-					return err
-				}
-			} else {
-				return fmt.Errorf("expected map for nested struct field '%s', got %T", propertyKey, value)
-			}
-			continue
-		}
-
-		// Handle pointer to struct
-		if field.Kind() == reflect.Ptr && field.Type().Elem().Kind() == reflect.Struct {
-			if valueMap, ok := value.(map[string]interface{}); ok {
-				if field.IsNil() {
-					field.Set(reflect.New(field.Type().Elem()))
-				}
-				err := setStructFields(field.Elem(), valueMap)
-				if err != nil {
-					return err
-				}
-			} else {
-				return fmt.Errorf("expected map for nested struct pointer field '%s', got %T", propertyKey, value)
-			}
-			continue
-		}
-
-		// Check if the field implements TextUnmarshaler
-		if field.CanInterface() {
-			if unmarshaler, ok := field.Addr().Interface().(TextUnmarshaler); ok {
-				err := unmarshaler.UnmarshalText([]byte(value.(string)))
-				if err != nil {
-					return fmt.Errorf("error unmarshaling field '%s': %v", propertyKey, err)
-				}
-				continue
-			}
-		}
-
-		// Set the field value
-		if valueStr, ok := value.(string); ok {
-			err := setFieldValue(field, valueStr)
-			if err != nil {
-				return fmt.Errorf("error setting field '%s': %v", propertyKey, err)
-			}
-		} else {
-			return fmt.Errorf("expected string value for field '%s', got %T", propertyKey, value)
+		if err := setStructField(field, fieldType, props); err != nil {
+			return err
 		}
 	}
 
 	return nil
 }
 
-// Helper function to extract key-value pair for PropUnmarshaler
-func extractKeyValue(propertyKey string, value interface{}) (string, string, error) {
+var (
+	propUnmarshallerType = reflect.TypeOf((*PropUnmarshaller)(nil)).Elem()
+	textUnmarshallerType = reflect.TypeOf((*TextUnmarshaler)(nil)).Elem()
+)
+
+func setStructField(field reflect.Value, fieldType reflect.StructField, props map[string]any) error {
+	if fieldType.Anonymous {
+		return setEmbeddedStructField(field, props)
+	}
+
+	propertyKey := fieldType.Tag.Get("property")
+	if propertyKey == "" {
+		propertyKey = fieldType.Name
+	}
+
+	value, ok := getNestedProperty(props, propertyKey)
+	if !ok {
+		return nil
+	}
+
+	return applyFieldValue(field, propertyKey, value)
+}
+
+func setEmbeddedStructField(field reflect.Value, props map[string]any) error {
+	switch field.Kind() {
+	case reflect.Struct:
+		return setStructFields(field, props)
+	case reflect.Ptr:
+		if field.Type().Elem().Kind() != reflect.Struct {
+			return nil
+		}
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+		return setStructFields(field.Elem(), props)
+	default:
+		return nil
+	}
+}
+
+func applyFieldValue(field reflect.Value, propertyKey string, value any) error {
+	if handled, err := applyPropUnmarshaller(field, propertyKey, value); handled {
+		return err
+	}
+	if handled, err := applyNestedStruct(field, propertyKey, value); handled {
+		return err
+	}
+	if handled, err := applyTextUnmarshaller(field, propertyKey, value); handled {
+		return err
+	}
+
+	valueStr, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("expected string value for field '%s', got %T", propertyKey, value)
+	}
+
+	if err := setFieldValue(field, valueStr); err != nil {
+		return fmt.Errorf("error setting field '%s': %w", propertyKey, err)
+	}
+	return nil
+}
+
+func applyPropUnmarshaller(field reflect.Value, propertyKey string, value any) (bool, error) {
+	target, ok := interfaceValue(field, propUnmarshallerType)
+	if !ok {
+		return false, nil
+	}
+
+	unmarshaler, ok := target.(PropUnmarshaller)
+	if !ok {
+		return false, nil
+	}
+
+	key, valStr, err := extractKeyValue(propertyKey, value)
+	if err != nil {
+		return true, fmt.Errorf("error extracting key-value for field '%s': %w", propertyKey, err)
+	}
+
+	if err := unmarshaler.UnmarshalProp(key, valStr); err != nil {
+		return true, fmt.Errorf("error unmarshaling field '%s': %w", propertyKey, err)
+	}
+	return true, nil
+}
+
+func applyNestedStruct(field reflect.Value, propertyKey string, value any) (bool, error) {
+	switch field.Kind() {
+	case reflect.Struct:
+		subProps, ok := value.(map[string]any)
+		if !ok {
+			return true, fmt.Errorf("expected map for nested struct field '%s', got %T", propertyKey, value)
+		}
+		return true, setStructFields(field, subProps)
+	case reflect.Ptr:
+		if field.Type().Elem().Kind() != reflect.Struct {
+			return false, nil
+		}
+		subProps, ok := value.(map[string]any)
+		if !ok {
+			return true, fmt.Errorf("expected map for nested struct pointer field '%s', got %T", propertyKey, value)
+		}
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+		return true, setStructFields(field.Elem(), subProps)
+	default:
+		return false, nil
+	}
+}
+
+func applyTextUnmarshaller(field reflect.Value, propertyKey string, value any) (bool, error) {
+	target, ok := interfaceValue(field, textUnmarshallerType)
+	if !ok {
+		return false, nil
+	}
+
+	valueStr, ok := value.(string)
+	if !ok {
+		return true, fmt.Errorf("expected string value for field '%s', got %T", propertyKey, value)
+	}
+
+	unmarshaler, ok := target.(TextUnmarshaler)
+	if !ok {
+		return false, nil
+	}
+
+	if err := unmarshaler.UnmarshalText([]byte(valueStr)); err != nil {
+		return true, fmt.Errorf("error unmarshaling field '%s': %w", propertyKey, err)
+	}
+	return true, nil
+}
+
+func interfaceValue(field reflect.Value, iface reflect.Type) (any, bool) {
+	if !field.IsValid() {
+		return nil, false
+	}
+
+	if field.Kind() == reflect.Ptr {
+		if !field.Type().Implements(iface) {
+			return nil, false
+		}
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+		if field.CanInterface() {
+			return field.Interface(), true
+		}
+		return nil, false
+	}
+
+	if field.Type().Implements(iface) && field.CanInterface() {
+		return field.Interface(), true
+	}
+
+	if field.CanAddr() && field.Addr().Type().Implements(iface) {
+		return field.Addr().Interface(), true
+	}
+
+	return nil, false
+}
+
+// Helper function to extract key-value pair for PropUnmarshaler.
+func extractKeyValue(propertyKey string, value any) (string, string, error) {
 	valueStr, ok := value.(string)
 	if !ok {
 		return "", "", fmt.Errorf("expected string value for property '%s', got %T", propertyKey, value)
@@ -244,7 +312,24 @@ func setFieldValue(field reflect.Value, valueStr string) error {
 			return fmt.Errorf("invalid float value '%s' for field", valueStr)
 		}
 		field.SetFloat(floatVal)
-	default:
+	case reflect.Uintptr:
+		uintVal, err := strconv.ParseUint(valueStr, 10, field.Type().Bits())
+		if err != nil {
+			return fmt.Errorf("invalid unsigned integer value '%s' for field", valueStr)
+		}
+		field.SetUint(uintVal)
+	case reflect.Invalid,
+		reflect.Complex64,
+		reflect.Complex128,
+		reflect.Array,
+		reflect.Chan,
+		reflect.Func,
+		reflect.Interface,
+		reflect.Map,
+		reflect.Ptr,
+		reflect.Slice,
+		reflect.Struct,
+		reflect.UnsafePointer:
 		return fmt.Errorf("unsupported field type: %s", field.Kind())
 	}
 	return nil

--- a/properties_test.go
+++ b/properties_test.go
@@ -1,11 +1,12 @@
-package dotprops
+package dotprops_test
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/rhajizada/dotprops"
 )
 
-// TestParseProperties tests the parseProperties function to ensure it correctly parses the properties data.
+// TestParseProperties exercises the parser through Unmarshal with nested keys.
 func TestParseProperties(t *testing.T) {
 	data := []byte(`
 # This is a comment
@@ -16,26 +17,37 @@ key3.subkey1=value3
 key3.subkey2=value4
 `)
 
-	expected := map[string]interface{}{
-		"key1": "value1",
-		"key2": "value2",
-		"key3": map[string]interface{}{
-			"subkey1": "value3",
-			"subkey2": "value4",
-		},
+	type Key3Config struct {
+		Subkey1 string `property:"subkey1"`
+		Subkey2 string `property:"subkey2"`
+	}
+	type Config struct {
+		Key1 string     `property:"key1"`
+		Key2 string     `property:"key2"`
+		Key3 Key3Config `property:"key3"`
 	}
 
-	props, err := parseProperties(data)
+	var config Config
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
-		t.Fatalf("parseProperties failed: %v", err)
+		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
-	if !reflect.DeepEqual(props, expected) {
-		t.Errorf("Expected props to be %+v, got %+v", expected, props)
+	if config.Key1 != "value1" {
+		t.Errorf("Expected Key1 'value1', got '%s'", config.Key1)
+	}
+	if config.Key2 != "value2" {
+		t.Errorf("Expected Key2 'value2', got '%s'", config.Key2)
+	}
+	if config.Key3.Subkey1 != "value3" {
+		t.Errorf("Expected Key3.Subkey1 'value3', got '%s'", config.Key3.Subkey1)
+	}
+	if config.Key3.Subkey2 != "value4" {
+		t.Errorf("Expected Key3.Subkey2 'value4', got '%s'", config.Key3.Subkey2)
 	}
 }
 
-// TestParsePropertiesInvalidLine ensures that invalid lines are ignored or handled appropriately.
+// TestParsePropertiesInvalidLine ensures invalid lines are ignored.
 func TestParsePropertiesInvalidLine(t *testing.T) {
 	data := []byte(`
 key1=value1
@@ -43,37 +55,38 @@ invalid_line_without_equals
 key2=value2
 `)
 
-	expected := map[string]interface{}{
-		"key1": "value1",
-		"key2": "value2",
+	type Config struct {
+		Key1 string `property:"key1"`
+		Key2 string `property:"key2"`
 	}
 
-	props, err := parseProperties(data)
+	var config Config
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
-		t.Fatalf("parseProperties failed: %v", err)
+		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
-	if !reflect.DeepEqual(props, expected) {
-		t.Errorf("Expected props to be %+v, got %+v", expected, props)
+	if config.Key1 != "value1" {
+		t.Errorf("Expected Key1 'value1', got '%s'", config.Key1)
+	}
+	if config.Key2 != "value2" {
+		t.Errorf("Expected Key2 'value2', got '%s'", config.Key2)
 	}
 }
 
-// TestSetStructFields_Simple tests setStructFields with a simple struct and correct property values.
+// TestSetStructFields_Simple tests Unmarshal with a simple struct and correct property values.
 func TestSetStructFields_Simple(t *testing.T) {
 	type Config struct {
 		Name string `property:"name"`
 		Age  int    `property:"age"`
 	}
 
-	props := map[string]interface{}{
-		"name": "Alice",
-		"age":  "30",
-	}
+	data := []byte("name=Alice\nage=30\n")
 
 	var config Config
-	err := setStructFields(reflect.ValueOf(&config).Elem(), props)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
-		t.Fatalf("setStructFields failed: %v", err)
+		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
 	if config.Name != "Alice" {
@@ -84,7 +97,7 @@ func TestSetStructFields_Simple(t *testing.T) {
 	}
 }
 
-// TestSetStructFields_Nested tests setStructFields with a nested struct and correct property values.
+// TestSetStructFields_Nested tests Unmarshal with nested structs and correct property values.
 func TestSetStructFields_Nested(t *testing.T) {
 	type InnerConfig struct {
 		SubName string `property:"sub.name"`
@@ -96,20 +109,12 @@ func TestSetStructFields_Nested(t *testing.T) {
 		Inner InnerConfig `property:"inner"`
 	}
 
-	props := map[string]interface{}{
-		"name": "Outer",
-		"inner": map[string]interface{}{
-			"sub": map[string]interface{}{
-				"name": "Inner",
-			},
-			"value": "100",
-		},
-	}
+	data := []byte("name=Outer\ninner.sub.name=Inner\ninner.value=100\n")
 
 	var config OuterConfig
-	err := setStructFields(reflect.ValueOf(&config).Elem(), props)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
-		t.Fatalf("setStructFields failed: %v", err)
+		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
 	if config.Name != "Outer" {
@@ -123,7 +128,7 @@ func TestSetStructFields_Nested(t *testing.T) {
 	}
 }
 
-// TestSetStructFields_PointerNested tests setStructFields with a pointer to a nested struct.
+// TestSetStructFields_PointerNested tests Unmarshal with a pointer to a nested struct.
 func TestSetStructFields_PointerNested(t *testing.T) {
 	type InnerConfig struct {
 		SubName string `property:"sub.name"`
@@ -135,20 +140,12 @@ func TestSetStructFields_PointerNested(t *testing.T) {
 		Inner *InnerConfig `property:"inner"`
 	}
 
-	props := map[string]interface{}{
-		"name": "Outer",
-		"inner": map[string]interface{}{
-			"sub": map[string]interface{}{
-				"name": "Inner",
-			},
-			"value": "100",
-		},
-	}
+	data := []byte("name=Outer\ninner.sub.name=Inner\ninner.value=100\n")
 
 	var config OuterConfig
-	err := setStructFields(reflect.ValueOf(&config).Elem(), props)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
-		t.Fatalf("setStructFields failed: %v", err)
+		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
 	if config.Name != "Outer" {
@@ -165,48 +162,42 @@ func TestSetStructFields_PointerNested(t *testing.T) {
 	}
 }
 
-// TestSetStructFields_TypeMismatch tests setStructFields with a type mismatch.
+// TestSetStructFields_TypeMismatch tests Unmarshal with a type mismatch.
 func TestSetStructFields_TypeMismatch(t *testing.T) {
 	type Config struct {
 		Name string `property:"name"`
 		Age  int    `property:"age"`
 	}
 
-	props := map[string]interface{}{
-		"name": "Bob",
-		"age":  "not_an_int",
-	}
+	data := []byte("name=Bob\nage=not_an_int\n")
 
 	var config Config
-	err := setStructFields(reflect.ValueOf(&config).Elem(), props)
+	err := dotprops.Unmarshal(data, &config)
 	if err == nil {
-		t.Fatal("Expected setStructFields to fail due to type mismatch, but it did not")
+		t.Fatal("Expected Unmarshal to fail due to type mismatch, but it did not")
 	}
 
-	// Since 'age' couldn't be set due to type mismatch, it should remain at zero value
 	if config.Age != 0 {
 		t.Errorf("Expected Age to be 0, got %d", config.Age)
 	}
 }
 
-// TestSetStructFields_UnsupportedType tests setStructFields with an unsupported field type.
+// TestSetStructFields_UnsupportedType tests Unmarshal with an unsupported field type.
 func TestSetStructFields_UnsupportedType(t *testing.T) {
 	type Config struct {
 		Channel chan int `property:"channel"`
 	}
 
-	props := map[string]interface{}{
-		"channel": "data",
-	}
+	data := []byte("channel=data\n")
 
 	var config Config
-	err := setStructFields(reflect.ValueOf(&config).Elem(), props)
+	err := dotprops.Unmarshal(data, &config)
 	if err == nil {
-		t.Fatal("Expected setStructFields to fail due to unsupported field type, but it did not")
+		t.Fatal("Expected Unmarshal to fail due to unsupported field type, but it did not")
 	}
 }
 
-// TestSetStructFields_UnsupportedNestedType tests setStructFields with an unsupported nested field type.
+// TestSetStructFields_UnsupportedNestedType tests Unmarshal with an unsupported nested field type.
 func TestSetStructFields_UnsupportedNestedType(t *testing.T) {
 	type InnerConfig struct {
 		Channel chan int `property:"channel"`
@@ -217,21 +208,16 @@ func TestSetStructFields_UnsupportedNestedType(t *testing.T) {
 		Inner InnerConfig `property:"inner"`
 	}
 
-	props := map[string]interface{}{
-		"name": "Outer",
-		"inner": map[string]interface{}{
-			"channel": "data",
-		},
-	}
+	data := []byte("name=Outer\ninner.channel=data\n")
 
 	var config OuterConfig
-	err := setStructFields(reflect.ValueOf(&config).Elem(), props)
+	err := dotprops.Unmarshal(data, &config)
 	if err == nil {
-		t.Fatal("Expected setStructFields to fail due to unsupported nested field type, but it did not")
+		t.Fatal("Expected Unmarshal to fail due to unsupported nested field type, but it did not")
 	}
 }
 
-// TestSetStructFields_PartialData tests setStructFields with partial data (missing some fields).
+// TestSetStructFields_PartialData tests Unmarshal with partial data (missing some fields).
 func TestSetStructFields_PartialData(t *testing.T) {
 	type Config struct {
 		Name    string `property:"name"`
@@ -239,16 +225,12 @@ func TestSetStructFields_PartialData(t *testing.T) {
 		Address string `property:"address"`
 	}
 
-	props := map[string]interface{}{
-		"name": "Charlie",
-		"age":  "25",
-		// 'address' is missing
-	}
+	data := []byte("name=Charlie\nage=25\n")
 
 	var config Config
-	err := setStructFields(reflect.ValueOf(&config).Elem(), props)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
-		t.Fatalf("setStructFields failed: %v", err)
+		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
 	if config.Name != "Charlie" {
@@ -262,23 +244,18 @@ func TestSetStructFields_PartialData(t *testing.T) {
 	}
 }
 
-// TestSetStructFields_ExtraProperties tests setStructFields with extra properties not present in the struct.
+// TestSetStructFields_ExtraProperties tests Unmarshal with extra properties not present in the struct.
 func TestSetStructFields_ExtraProperties(t *testing.T) {
 	type Config struct {
 		Name string `property:"name"`
 	}
 
-	props := map[string]interface{}{
-		"name":      "Dana",
-		"unknown":   "value",
-		"another":   "value",
-		"extra.key": "extra_value",
-	}
+	data := []byte("name=Dana\nunknown=value\nanother=value\nextra.key=extra_value\n")
 
 	var config Config
-	err := setStructFields(reflect.ValueOf(&config).Elem(), props)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
-		t.Fatalf("setStructFields failed: %v", err)
+		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
 	if config.Name != "Dana" {

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -5,7 +5,8 @@ import (
 	"reflect"
 )
 
-func Unmarshal(data []byte, v interface{}) error {
+// Unmarshal parses properties data into the struct pointed to by v.
+func Unmarshal(data []byte, v any) error {
 	val := reflect.ValueOf(v)
 
 	// Ensure v is a pointer to a struct

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -1,7 +1,9 @@
-package dotprops
+package dotprops_test
 
 import (
 	"testing"
+
+	"github.com/rhajizada/dotprops"
 )
 
 // Existing Tests
@@ -14,7 +16,7 @@ app.debug=true
 `)
 
 	var config SimpleConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -40,7 +42,7 @@ database.password=secret
 `)
 
 	var config NestedConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -69,7 +71,7 @@ app.port=8080
 `)
 
 	var config OptionalConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -96,7 +98,7 @@ func TestUnmarshalUnsupportedFieldType(t *testing.T) {
 
 	data := []byte("data=one,two,three")
 
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err == nil {
 		t.Fatal("Expected Unmarshal to fail due to unsupported field type, but it did not")
 	}
@@ -115,7 +117,7 @@ app.debug=not_a_boolean
 `)
 
 	var config SimpleConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err == nil {
 		t.Fatal("Expected Unmarshal to fail due to invalid boolean value, but it did not")
 	}
@@ -136,7 +138,7 @@ database.password=toor
 `)
 
 	var config ConfigWithPointer
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -171,7 +173,7 @@ database.port=invalid_port
 `)
 
 	var config NestedConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err == nil {
 		t.Fatal("Expected Unmarshal to fail due to type mismatch in nested struct, but it did not")
 	}
@@ -196,7 +198,7 @@ count=custom_42
 `)
 
 	var config CustomConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -221,7 +223,7 @@ count=custom_42
 `)
 
 	var config CustomConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err == nil {
 		t.Fatal("Expected Unmarshal to fail due to invalid prefix in 'name', but it did not")
 	}
@@ -242,7 +244,7 @@ rate=custom_99.99
 `)
 
 	var config FloatConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -263,7 +265,7 @@ rate=invalid_99.99
 `)
 
 	var config FloatConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err == nil {
 		t.Fatal("Expected Unmarshal to fail due to invalid prefix in 'rate', but it did not")
 	}
@@ -288,7 +290,7 @@ threshold=75.5
 `)
 
 	var config NumericConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -310,7 +312,7 @@ service.endpoint.active=true
 `)
 
 	var config MultiLevelNestedConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -336,6 +338,7 @@ func TestUnmarshalWithEmbeddedStruct(t *testing.T) {
 
 	type EmbeddedConfig struct {
 		BaseConfig
+
 		Name string `property:"name"`
 	}
 
@@ -345,7 +348,7 @@ name=EmbeddedService
 `)
 
 	var config EmbeddedConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -374,7 +377,7 @@ inner.data=one,two
 `)
 
 	var config OuterConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err == nil {
 		t.Fatal("Expected Unmarshal to fail due to unsupported nested struct field type, but it did not")
 	}
@@ -396,7 +399,7 @@ name=IncompleteService
 `)
 
 	var config CompleteConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -421,7 +424,7 @@ another.key=another_value
 `)
 
 	var config Config
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -444,7 +447,7 @@ version=1.2.3
 `)
 
 	var config Config
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -468,7 +471,7 @@ name=Second
 `)
 
 	var config Config
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -489,6 +492,7 @@ func TestUnmarshalWithMultipleEmbeddedStructs(t *testing.T) {
 	type EmbeddedConfig struct {
 		BaseConfig
 		SecurityConfig
+
 		Name string `property:"name"`
 	}
 
@@ -499,7 +503,7 @@ func TestUnmarshalWithMultipleEmbeddedStructs(t *testing.T) {
 	`)
 
 	var config EmbeddedConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -521,6 +525,7 @@ func TestUnmarshalWithPointerEmbeddedStructs(t *testing.T) {
 	}
 	type EmbeddedConfig struct {
 		*BaseConfig
+
 		Name string `property:"name"`
 	}
 
@@ -530,7 +535,7 @@ func TestUnmarshalWithPointerEmbeddedStructs(t *testing.T) {
 	`)
 
 	var config EmbeddedConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -558,7 +563,7 @@ func TestUnmarshalWithCustomTextUnmarshaler(t *testing.T) {
 	`)
 
 	var config CustomConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -586,7 +591,7 @@ func TestUnmarshalWithUnsupportedNestedStructTypes(t *testing.T) {
 	`)
 
 	var config OuterConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err == nil {
 		t.Fatal("Expected Unmarshal to fail due to unsupported nested struct field type, but it did not")
 	}
@@ -620,7 +625,7 @@ func TestUnmarshalWithMultipleLevelsNestedStructs(t *testing.T) {
 	`)
 
 	var config OuterConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -642,6 +647,7 @@ func TestUnmarshalWithMissingEmbeddedStructFields(t *testing.T) {
 	}
 	type EmbeddedConfig struct {
 		BaseConfig
+
 		Name string `property:"name"`
 	}
 
@@ -650,7 +656,7 @@ func TestUnmarshalWithMissingEmbeddedStructFields(t *testing.T) {
 	`)
 
 	var config EmbeddedConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -675,7 +681,7 @@ func TestUnmarshalWithExtraProperties(t *testing.T) {
 	`)
 
 	var config Config
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -698,7 +704,7 @@ func TestUnmarshalWithWhitespace(t *testing.T) {
 	`)
 
 	var config Config
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -711,7 +717,7 @@ func TestUnmarshalWithWhitespace(t *testing.T) {
 	}
 }
 
-// TestUnmarshalWithPropUnmarshaler tests unmarshalling with PropUnmarshaler interface
+// TestUnmarshalWithPropUnmarshaler tests unmarshalling with PropUnmarshaler interface.
 func TestUnmarshalWithPropUnmarshaler(t *testing.T) {
 	type CustomConfig struct {
 		CustomField CustomPropUnmarshaller `property:"custom.field"`
@@ -724,7 +730,7 @@ name=TestService
 `)
 
 	var config CustomConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err != nil {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
@@ -740,7 +746,7 @@ name=TestService
 	}
 }
 
-// TestUnmarshalWithPropUnmarshalerError tests unmarshalling when PropUnmarshaler returns an error
+// TestUnmarshalWithPropUnmarshalerError tests unmarshalling when PropUnmarshaler returns an error.
 func TestUnmarshalWithPropUnmarshalerError(t *testing.T) {
 	data := []byte(`
 faulty.field=invalid_value
@@ -748,7 +754,7 @@ name=FaultyService
 `)
 
 	var config FaultyConfig
-	err := Unmarshal(data, &config)
+	err := dotprops.Unmarshal(data, &config)
 	if err == nil {
 		t.Fatal("Expected Unmarshal to fail due to PropUnmarshaler error, but it did not")
 	}


### PR DESCRIPTION
## Changes

- refactor marshal/unmarshal helpers for exhaustive kind handling
- fix errcheck/forbidigo issues and DBConfig naming
- move tests to dotprops_test and update imports/usages
- add/update lint config and Makefile tweaks
- added new badges to `README.md`
- updated `ci.yml` workflow and added step to parse coverage report and update badge value
- added dependabot configuration